### PR TITLE
new features: add creation time variables and custom attribute variables

### DIFF
--- a/FileTemplates.py
+++ b/FileTemplates.py
@@ -2,7 +2,6 @@ import os, time, re
 import sublime
 import sublime_plugin
 import glob
-import os
 from xml.etree import ElementTree
 
 current_path = None
@@ -25,6 +24,8 @@ class CreateFileFromTemplateCommand(sublime_plugin.WindowCommand):
             os.makedirs(os.path.dirname(path))
 
         open(path, 'w')
+
+        self.other_input()
 
         global template
         template = {
@@ -195,6 +196,16 @@ class CreateFileFromTemplateCommand(sublime_plugin.WindowCommand):
             return
         else:
             self.create_and_open_file(full_path)
+
+    def other_input(self):
+        attrs = self.get_setting("attrs")
+        if attrs:
+            self.variables.update(attrs)
+
+        timepatterns = self.get_setting("creation_time")
+        if timepatterns:
+            for key, pattern in timepatterns.iteritems():
+                self.variables[key] = time.strftime(pattern)
 
     def show_quick_panel(self, options, done):
         sublime.set_timeout(lambda: self.window.show_quick_panel(options, done), 10)

--- a/FileTemplates.sublime-settings
+++ b/FileTemplates.sublime-settings
@@ -1,5 +1,21 @@
 {
   "excluded_dir_patterns": [
     "tmp", "|.git", "|.svn"
-  ]
+  ],
+  "attrs": {
+    "author": "author",
+    "company": "company",
+    "email": "email",
+    "github": "github"
+  },
+  "creation_time": {
+    "day": "%d",
+    "month": "%m",
+    "year": "%Y",
+    "short_weekdayname": "%a",
+    "weekdayname": "%A",
+    "short_monthname": "%b",
+    "date": "%d/%m/%Y",
+    "time": "%H:%M:%S"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,42 @@ you can restrict the key bindings to command mode like this:
 
     { "keys": [" ", "n"], "command": "create_file_from_template", "context": [{"key": "setting.command_mode"}] }
 
+## New Features
+
+- add **time** and **date** variables,
+  
+  > record file creation time
+  > 
+``` json
+  "creation_time": {
+    "day": "%d",
+    "month": "%m",
+    "year": "%Y",
+    "short_weekdayname": "%a",
+    "weekdayname": "%A",
+    "short_monthname": "%b",
+    "date": "%d/%m/%Y",
+    "time": "%H:%M:%S"
+  }
+```
+
+  > use `$day`, `$date`, `$time`, ... in your templates.
+
+- add customizable **attrs** variable,
+  
+  > add custom variables
+  > 
+``` json
+  "attrs": {
+    "author": "Your Name",
+    "company": "Your Company",
+    "email": "you@example.org",
+    "github": "github.com/you",
+    "foo": "bar"
+  }
+```
+
+  > use `$author`, `$company`, `$email`, `$github`, `$foo` in your templates.
 
 ## Thanks
 


### PR DESCRIPTION
Hi mneuhaus, 

This is a handy plugin and I've been using it for a while.

just added some simple features so that we can also 
- record the file creation time 
- use custom keys defined in the settings

New keys include datetime variables like $date, $time and custom variables like $author, $company. 
